### PR TITLE
removed data= construct that dies with astropy 1.0.5

### DIFF
--- a/reducer/astro_gui.py
+++ b/reducer/astro_gui.py
@@ -124,7 +124,7 @@ class Reduction(ReducerBase):
                     unit = hdu.header['BUNIT']
                 except KeyError:
                     unit = DEFAULT_IMAGE_UNIT
-                ccd = ccdproc.CCDData(data=hdu.data, meta=hdu.header, unit=unit)
+                ccd = ccdproc.CCDData(hdu.data, meta=hdu.header, unit=unit)
 
                 for child in self.container.children:
                     if not child.toggle.value:
@@ -423,7 +423,7 @@ class Combiner(ReducerBase):
                 unit = hdu.header['BUNIT']
             except KeyError:
                 unit = DEFAULT_IMAGE_UNIT
-            images.append(ccdproc.CCDData(data=hdu.data,
+            images.append(ccdproc.CCDData(hdu.data,
                                           meta=hdu.header,
                                           unit=unit))
         combiner = ccdproc.Combiner(images, dtype=images[0].dtype)


### PR DESCRIPTION
Changes to CCDproc break reducer since it constructs CCDData objects with the ```data=``` syntax