### PR TITLE
fix the missing comment for remove_class

### DIFF
--- a/reducer/gui.py
+++ b/reducer/gui.py
@@ -480,7 +480,7 @@ def set_color_for(a_widget):
                 # a_widget.toggle.add_class('btn-success')
                 a_widget.toggle.button_style = 'success'
         else:
-            a_widget.toggle.remove_class('btn-success')
-            a_widget.toggle.remove_class('btn-warning')
+            # a_widget.toggle.remove_class('btn-success')
+            # a_widget.toggle.remove_class('btn-warning')
             a_widget.toggle.button_style = None
     return set_color

--- a/reducer/gui.py
+++ b/reducer/gui.py
@@ -472,15 +472,9 @@ def set_color_for(a_widget):
     def set_color(name, value):
         if a_widget.toggle.value:
             if not a_widget.is_sane:
-                # a_widget.toggle.remove_class('btn-success')
-                # a_widget.toggle.add_class('btn-warning')
                 a_widget.toggle.button_style = 'warning'
             else:
-                # a_widget.toggle.remove_class('btn-warning')
-                # a_widget.toggle.add_class('btn-success')
                 a_widget.toggle.button_style = 'success'
         else:
-            # a_widget.toggle.remove_class('btn-success')
-            # a_widget.toggle.remove_class('btn-warning')
             a_widget.toggle.button_style = None
     return set_color


### PR DESCRIPTION
When using reducer with ipywidgets 4.1.1, the gui crashes when pressing
a toggle twice.

There were simply comments forgotten.