### PR TITLE
Fixed Image Browser to handle non-float images

### DIFF
--- a/reducer/image_browser.py
+++ b/reducer/image_browser.py
@@ -213,7 +213,7 @@ def ndarray_to_png(x):
     aspect = shape[1]/shape[0]
     width = 600  # pixels
     new_shape = np.asarray(width/shape[0]*aspect*shape, dtype='int')
-    x = np.asarray(Image.fromarray(x).resize(new_shape))
+    x = np.asarray(Image.fromarray(x.astype('float32')).resize(new_shape))
     x = (x - x.mean()) / x.std()
     x[x >= 3] = 2.99
     x[x < -3] = -3.0


### PR DESCRIPTION
Fixed Image Browser to handle non-float images (like unsigned 16-bit integers) by type-casting the data array to float before passing it to Pillow's Image.fromarray() routine.  Resolves issue #115 